### PR TITLE
Add http2 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = vhost;
 function vhost(pattern, app) {
   return async (ctx, next) => {
     try {
-      const hostname = domainToUnicode(ctx.hostname);
+      const hostname = domainToUnicode(ctx.get(':authority') || ctx.hostname);
       const target = app || matchAndMap(hostname);
 
       if (!target) return await next();


### PR DESCRIPTION
When using http2 module the `hostname` will be empty and there is a new pseudo-header field named `:authority`
According to RFC 7540 in https://tools.ietf.org/html/rfc7540#section-8.1.2.3
```
   o  The ":authority" pseudo-header field includes the authority
      portion of the target URI ([RFC3986], Section 3.2).  The authority
      MUST NOT include the deprecated "userinfo" subcomponent for "http"
      or "https" schemed URIs.
```